### PR TITLE
fix: move .DataModels to net standard

### DIFF
--- a/ScheduleAggregator.Core/ScheduleAggregator.Core.csproj
+++ b/ScheduleAggregator.Core/ScheduleAggregator.Core.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ScheduleAggregator.DataModels/Repositories/GenericRepository.cs
+++ b/ScheduleAggregator.DataModels/Repositories/GenericRepository.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Data.Entity;
 using System.Linq;
-using Microsoft.EntityFrameworkCore;
 
 namespace ScheduleAggregator.DataModels.Repositories
 {

--- a/ScheduleAggregator.DataModels/Repositories/ScheduleContext.cs
+++ b/ScheduleAggregator.DataModels/Repositories/ScheduleContext.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Data.Entity;
 using ScheduleAggregator.DataModels.Entities;
-
 
 namespace ScheduleAggregator.DataModels.Repositories
 {
     public class ScheduleContext : DbContext
     {
 
-        public ScheduleContext(DbContextOptions<ScheduleContext> options)
-        : base(options)
-        { }
+        //TODO: fix
+        //public ScheduleContext(DbContextOptions<ScheduleContext> options)
+        //: base(options)
+        //{ }
 
         public DbSet<LabourIntensity> LabourIntensities{ get; set; }
         public DbSet<Lesson> Lessons{ get; set; }

--- a/ScheduleAggregator.DataModels/ScheduleAggregator.DataModels.csproj
+++ b/ScheduleAggregator.DataModels/ScheduleAggregator.DataModels.csproj
@@ -1,22 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Kysect.ItmoScheduleSdk" Version="1.0.4" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\ScheduleAggregator.Core\ScheduleAggregator.Core.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
       <Folder Include="Interfaces\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="EntityFramework" Version="6.2.0" />
+      <PackageReference Include="Kysect.ItmoScheduleSdk" Version="1.0.5" />
     </ItemGroup>
 
 </Project>

--- a/ScheduleAggregator.UiLegacy/ScheduleAggregator.UiLegacy.csproj
+++ b/ScheduleAggregator.UiLegacy/ScheduleAggregator.UiLegacy.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <RootNamespace>ScheduleAggregator.Ui</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ScheduleAggregator/ScheduleAggregator.csproj
+++ b/ScheduleAggregator/ScheduleAggregator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Выяснили, что у нас проекты с логикой на 5 дотнете, а UI на фреймворке т.к. UWP прям совсем никак не умеет. Варианта 3:
1. Переписать на MAUI который еще даже не поддерживается в студии
2. Переписать используя WinUI который в превью, но выглядит как дорога не туда
3. Перенести все на стандарт и переиспользовать.

Выбрал вариант 3, но помимо родственников пострадал также EntityFramework, пришлось коровскую реализацию заменить на фреймворковскую.